### PR TITLE
support both pwsh and powershell.exe in install/uninstall scripts

### DIFF
--- a/Install.bat
+++ b/Install.bat
@@ -1,1 +1,12 @@
-powershell.exe -executionpolicy bypass -file ./Installer.ps1 -n ResolutionMatcher -i 1
+@echo off
+where pwsh >nul 2>&1 || where powershell.exe >nul 2>&1 || (
+    echo No PowerShell installation found at all
+    pause
+    exit /b 1
+)
+where pwsh >nul 2>&1 && (
+    pwsh -executionpolicy bypass -file ./Installer.ps1 -n ResolutionMatcher -i 1
+) || (
+    powershell.exe -executionpolicy bypass -file ./Installer.ps1 -n ResolutionMatcher -i 1
+)
+pause

--- a/Uninstall.bat
+++ b/Uninstall.bat
@@ -1,1 +1,12 @@
-powershell.exe -executionpolicy bypass -file ./Installer.ps1 -n ResolutionMatcher -i 0
+@echo off
+where pwsh >nul 2>&1 || where powershell.exe >nul 2>&1 || (
+    echo No PowerShell installation found at all
+    pause
+    exit /b 1
+)
+where pwsh >nul 2>&1 && (
+    pwsh -executionpolicy bypass -file ./Installer.ps1 -n ResolutionMatcher -i 0
+) || (
+    powershell.exe -executionpolicy bypass -file ./Installer.ps1 -n ResolutionMatcher -i 0
+)
+pause


### PR DESCRIPTION
the script didn't work on windows powershell 7 machine.
I think this makes it more versatile and work on more machines and also show an error.

fix: support both pwsh and powershell.exe in install/uninstall scripts

- Add fallback to powershell.exe if pwsh not found
- Prevent silent failures by checking for PowerShell availability
- Add pause to show errors before window closes